### PR TITLE
Added member count to org info.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub enum Organization {
         sid: String,
         url: Box<Url>,
         rank: OrganizationRank,
+        member_count: usize,
     },
     Redacted,
 }


### PR DESCRIPTION
I added the ability to pars out and pass along the member count for each org since that information is visible on the player org page for main and affiliate(s).